### PR TITLE
fix href for release in pdf #patch

### DIFF
--- a/ccs-resume.tex
+++ b/ccs-resume.tex
@@ -178,7 +178,7 @@ powerlifting, yoga
 \rule{\linewidth}{.25pt}
 
 \small{This resume written in Xe\LaTeX using Emacs via \href{
-    https://github.com/carltonstedman/vitae/releases/tags/1.0.0}{
-    github.com/carltonstedman/vitae/releases/tags/1.0.0}}
+    https://github.com/carltonstedman/vitae/releases/tag/1.0.1}{
+    github.com/carltonstedman/vitae/releases/tag/1.0.1}}
 
 \end{document}


### PR DESCRIPTION
Hotfix, the hyperlink for releases should have "tag", not "tags".